### PR TITLE
Fix Context menu issues in handler file + folders

### DIFF
--- a/src/handlers/interaction.js
+++ b/src/handlers/interaction.js
@@ -16,6 +16,10 @@ module.exports = (client) => {
 
             if (pull.name) {
                 client.interactions.set(pull.name, pull);
+                if (["MESSAGE", "USER"].includes(file.type)) delete file.description;
+                /*  Context menus use the message and user type, but dont use a description unlike slash commands, which use the CHAT_INPUT type, and has a description. Be sure to decipher between the two.
+                    See: https://discord.js.org/#/docs/main/stable/typedef/ApplicationCommandType
+                */
                 slash.push(pull);
                 table.addRow(file, '✔ Ready');
             } else {

--- a/src/interactions/Information/Context/avatar.js
+++ b/src/interactions/Information/Context/avatar.js
@@ -15,7 +15,7 @@ module.exports = {
     run: async (client, interaction) => {
         const user = interaction.user;
 
-        const avatarEmed = new MessageEmbed()
+        const avatarEmbed = new MessageEmbed()
             .setTitle(`${user.tag}'s Avatar`)
             .setColor(user.displayHexColor)
             .setImage(user.displayAvatarURL({
@@ -24,7 +24,7 @@ module.exports = {
             }))
 
         interaction.followUp({
-            embeds: [avatarEmed]
+            embeds: [avatarEmbed]
         });
     }
 }

--- a/src/interactions/Information/Slash/ping.js
+++ b/src/interactions/Information/Slash/ping.js
@@ -1,0 +1,20 @@
+const {
+    Client,
+    Interaction
+} = require("discord.js")
+module.exports = {
+    name: 'ping',
+    description: 'My ping.',
+    type:'CHAT_INPUT',
+    /**  
+    * {param} {Client} client
+    * {param} {Interaction} interaction
+    * {param} {String[]} args
+    */
+    run: async (client, interaction, args) => {
+        await interaction.reply({
+            content: 'My ping is `' + client.ws.ping + '`!',
+            ephemeral:true
+        })
+    }
+}

--- a/src/interactions/Information/ping.js
+++ b/src/interactions/Information/ping.js
@@ -1,9 +1,0 @@
-module.exports = {
-    name: 'ping',
-    description: 'My ping.',
-    run: async (client, interaction, args) => {
-        await interaction.reply({
-            content: 'My ping is `' + client.ws.ping + '`!'
-        })
-    }
-}


### PR DESCRIPTION
Resolved issues that differentiate context menu commands from slash commands, as context menus do not have descriptions whereas slash commands do use a description, and added folders for those slash commands, as done with the context menu folder a slash command folder was added.
Also matched the way that both files are executed, using docstring parameters.